### PR TITLE
disable LCP profile URI / name customization

### DIFF
--- a/platform/apple/src/LCPError.h
+++ b/platform/apple/src/LCPError.h
@@ -34,7 +34,9 @@ extern NSString *const LCPErrorExtensionKey;
 // @see LcpStatus.h for documentation
 extern NSInteger const LCPErrorCommonNoNetProvider;
 extern NSInteger const LCPErrorCommonNoStorageProvider;
+#if ENABLE_PROFILE_NAMES
 extern NSInteger const LCPErrorCommonEncryptionProfileNotFound;
+#endif //ENABLE_PROFILE_NAMES
 extern NSInteger const LCPErrorCommonAlgorithmMismatch;
 extern NSInteger const LCPErrorOpeningLicenseNotValid;
 extern NSInteger const LCPErrorOpeningLicenseNotStarted;

--- a/src/lcp-client-lib/CryptoLcpNode.cpp
+++ b/src/lcp-client-lib/CryptoLcpNode.cpp
@@ -96,11 +96,15 @@ namespace lcp
 
     Status CryptoLcpNode::VerifyNode(ILicense * license, IClientProvider * clientProvider, ICryptoProvider * cryptoProvider)
     {
+#if ENABLE_PROFILE_NAMES
         m_encryptionProfile = m_encryptionProfilesManager->GetProfile(m_cryptoInfo.encryptionProfile);
         if (m_encryptionProfile == nullptr)
         {
             return Status(StatusCode::ErrorCommonEncryptionProfileNotFound, "ErrorCommonEncryptionProfileNotFound");
         }
+#else
+        m_encryptionProfile = m_encryptionProfilesManager->GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
         if (m_encryptionProfile->ContentKeyAlgorithmCBC() != m_cryptoInfo.contentKeyAlgorithm && m_encryptionProfile->ContentKeyAlgorithmGCM() != m_cryptoInfo.contentKeyAlgorithm)
         {

--- a/src/lcp-client-lib/CryptoppCryptoProvider.cpp
+++ b/src/lcp-client-lib/CryptoppCryptoProvider.cpp
@@ -104,11 +104,15 @@ namespace lcp
     {
         try
         {
+#if ENABLE_PROFILE_NAMES
             IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile(license->Crypto()->EncryptionProfile());
             if (profile == nullptr)
             {
                 return Status(StatusCode::ErrorCommonEncryptionProfileNotFound, "ErrorCommonEncryptionProfileNotFound");
             }
+#else
+            IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
             if (rootCertificateBase64.empty())
             {
@@ -190,11 +194,15 @@ namespace lcp
     {
         try
         {
+#if ENABLE_PROFILE_NAMES
             IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile(license->Crypto()->EncryptionProfile());
             if (profile == nullptr)
             {
                 return Status(StatusCode::ErrorCommonEncryptionProfileNotFound, "ErrorCommonEncryptionProfileNotFound");
             }
+#else
+            IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
             std::unique_ptr<IHashAlgorithm> hashAlgorithm(profile->CreateUserKeyAlgorithm());
             hashAlgorithm->UpdateHash(userPassphrase);
@@ -226,11 +234,15 @@ namespace lcp
     {
         try
         {
+#if ENABLE_PROFILE_NAMES
             IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile(license->Crypto()->EncryptionProfile());
             if (profile == nullptr)
             {
                 return Status(StatusCode::ErrorCommonEncryptionProfileNotFound, "ErrorCommonEncryptionProfileNotFound");
             }
+#else
+            IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
             //http://www.w3.org/2009/xmlenc11#aes256-gcm
             //http://www.w3.org/2001/04/xmlenc#aes256-cbc
@@ -333,11 +345,15 @@ namespace lcp
     {
         try
         {
+#if ENABLE_PROFILE_NAMES
             IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile(license->Crypto()->EncryptionProfile());
             if (profile == nullptr)
             {
                 return Status(StatusCode::ErrorCommonEncryptionProfileNotFound, "ErrorCommonEncryptionProfileNotFound");
             }
+#else
+            IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
             //http://www.w3.org/2009/xmlenc11#aes256-gcm
             //http://www.w3.org/2001/04/xmlenc#aes256-cbc
@@ -365,11 +381,15 @@ namespace lcp
     {
         try
         {
+#if ENABLE_PROFILE_NAMES
             IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile(license->Crypto()->EncryptionProfile());
             if (profile == nullptr)
             {
                 return Status(StatusCode::ErrorCommonEncryptionProfileNotFound, "ErrorCommonEncryptionProfileNotFound");
             }
+#else
+            IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
             std::unique_ptr<ISymmetricAlgorithm> algo(profile->CreatePublicationAlgorithm(keyProvider->ContentKey(), algorithm));
             *decryptedDataLength = algo->Decrypt(
@@ -394,11 +414,15 @@ namespace lcp
     {
         try
         {
+#if ENABLE_PROFILE_NAMES
             IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile(license->Crypto()->EncryptionProfile());
             if (profile == nullptr)
             {
                 return Status(StatusCode::ErrorCommonEncryptionProfileNotFound, "ErrorCommonEncryptionProfileNotFound");
             }
+#else
+            IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
             Status res(StatusCode::ErrorCommonSuccess);
             std::unique_ptr<ISymmetricAlgorithm> algo(profile->CreatePublicationAlgorithm(keyProvider->ContentKey(), algorithm));

--- a/src/lcp-client-lib/EncryptionProfileNames.cpp
+++ b/src/lcp-client-lib/EncryptionProfileNames.cpp
@@ -30,4 +30,5 @@
 namespace lcp
 {
     /*static*/ std::string EncryptionProfileNames::Lcp1dot0ProfileId = "http://readium.org/lcp/profile-1.0";
+    /*static*/ std::string EncryptionProfileNames::LcpBasicProfileId = "http://readium.org/lcp/basic-profile";
 }

--- a/src/lcp-client-lib/EncryptionProfileNames.cpp
+++ b/src/lcp-client-lib/EncryptionProfileNames.cpp
@@ -27,8 +27,12 @@
 
 #include "EncryptionProfileNames.h"
 
+#if ENABLE_PROFILE_NAMES
+
 namespace lcp
 {
     /*static*/ std::string EncryptionProfileNames::Lcp1dot0ProfileId = "http://readium.org/lcp/profile-1.0";
     /*static*/ std::string EncryptionProfileNames::LcpBasicProfileId = "http://readium.org/lcp/basic-profile";
 }
+
+#endif //ENABLE_PROFILE_NAMES

--- a/src/lcp-client-lib/EncryptionProfileNames.h
+++ b/src/lcp-client-lib/EncryptionProfileNames.h
@@ -36,6 +36,7 @@ namespace lcp
     {
     public:
         static std::string Lcp1dot0ProfileId;
+        static std::string LcpBasicProfileId;
     };
 }
 

--- a/src/lcp-client-lib/EncryptionProfileNames.h
+++ b/src/lcp-client-lib/EncryptionProfileNames.h
@@ -28,6 +28,8 @@
 #ifndef __ENCRYPTION_PROFILE_NAMES_H__
 #define __ENCRYPTION_PROFILE_NAMES_H__
 
+#if ENABLE_PROFILE_NAMES
+
 #include <string>
 
 namespace lcp
@@ -39,5 +41,7 @@ namespace lcp
         static std::string LcpBasicProfileId;
     };
 }
+
+#endif //ENABLE_PROFILE_NAMES
 
 #endif //__ENCRYPTION_PROFILE_NAMES_H__

--- a/src/lcp-client-lib/EncryptionProfilesManager.cpp
+++ b/src/lcp-client-lib/EncryptionProfilesManager.cpp
@@ -32,10 +32,15 @@ namespace lcp
 {
     EncryptionProfilesManager::EncryptionProfilesManager()
     {
+#if ENABLE_PROFILE_NAMES
         std::unique_ptr<IEncryptionProfile> lcp1dot0(new Lcp1dot0EncryptionProfile());
         m_profilesMap.insert(std::make_pair(lcp1dot0->Name(), std::move(lcp1dot0)));
+#else
+        m_profile.reset(new Lcp1dot0EncryptionProfile());
+#endif //ENABLE_PROFILE_NAMES
     }
 
+#if ENABLE_PROFILE_NAMES
     bool EncryptionProfilesManager::RegisterProfile(std::unique_ptr<IEncryptionProfile> profile)
     {
         std::unique_lock<std::mutex> locker(m_profilesSync);
@@ -53,4 +58,10 @@ namespace lcp
         }
         return nullptr;
     }
+#else
+    IEncryptionProfile * EncryptionProfilesManager::GetProfile() const
+    {
+        return m_profile.get();
+    }
+#endif //ENABLE_PROFILE_NAMES
 }

--- a/src/lcp-client-lib/EncryptionProfilesManager.h
+++ b/src/lcp-client-lib/EncryptionProfilesManager.h
@@ -28,9 +28,12 @@
 #ifndef __ENCRYPTION_PROFILES_MANAGER_H__
 #define __ENCRYPTION_PROFILES_MANAGER_H__
 
+#if ENABLE_PROFILE_NAMES
 #include <map>
 #include <memory>
 #include <mutex>
+#endif //ENABLE_PROFILE_NAMES
+
 #include "IEncryptionProfile.h"
 #include "NonCopyable.h"
 
@@ -40,13 +43,21 @@ namespace lcp
     {
     public:
         EncryptionProfilesManager();
+#if ENABLE_PROFILE_NAMES
         bool RegisterProfile(std::unique_ptr<IEncryptionProfile> profile);
         IEncryptionProfile * GetProfile(const std::string & name) const;
+#else
+        IEncryptionProfile * GetProfile() const;
+#endif //ENABLE_PROFILE_NAMES
 
     private:
+#if ENABLE_PROFILE_NAMES
         typedef std::map<std::string, std::unique_ptr<IEncryptionProfile> > ProfilesMap;
         ProfilesMap m_profilesMap;
         mutable std::mutex m_profilesSync;
+#else
+        std::unique_ptr<IEncryptionProfile> m_profile;
+#endif //ENABLE_PROFILE_NAMES
     };
 }
 

--- a/src/lcp-client-lib/IEncryptionProfile.h
+++ b/src/lcp-client-lib/IEncryptionProfile.h
@@ -41,7 +41,9 @@ namespace lcp
     class IEncryptionProfile
     {
     public:
+#if ENABLE_PROFILE_NAMES
         virtual std::string Name() const = 0;
+#endif //ENABLE_PROFILE_NAMES
         virtual std::string UserKeyAlgorithm() const = 0;
         virtual std::string PublicationAlgorithmGCM() const = 0;
         virtual std::string PublicationAlgorithmCBC() const = 0;

--- a/src/lcp-client-lib/Lcp1dot0EncryptionProfile.cpp
+++ b/src/lcp-client-lib/Lcp1dot0EncryptionProfile.cpp
@@ -96,11 +96,18 @@ namespace lcp
         throw StatusException(Status(StatusCode::ErrorCommonAlgorithmMismatch, "ErrorCommonAlgorithmMismatch"));
     }
 
+#if ENABLE_PROFILE_NAMES
     std::string Lcp1dot0EncryptionProfile::Name() const
     {
         //http://readium.org/lcp/profile-1.0
         return EncryptionProfileNames::Lcp1dot0ProfileId;
+
+        ...OR?
+
+        //http://readium.org/lcp/basic-profile
+        return EncryptionProfileNames::LcpBasicProfileId
     }
+#endif //ENABLE_PROFILE_NAMES
 
     std::string Lcp1dot0EncryptionProfile::UserKeyAlgorithm() const
     {

--- a/src/lcp-client-lib/Lcp1dot0EncryptionProfile.cpp
+++ b/src/lcp-client-lib/Lcp1dot0EncryptionProfile.cpp
@@ -26,7 +26,11 @@
 
 
 #include "Lcp1dot0EncryptionProfile.h"
+
+#if ENABLE_PROFILE_NAMES
 #include "EncryptionProfileNames.h"
+#endif //ENABLE_PROFILE_NAMES
+
 #include "AlgorithmNames.h"
 
 #include "LcpUtils.h"

--- a/src/lcp-client-lib/Lcp1dot0EncryptionProfile.h
+++ b/src/lcp-client-lib/Lcp1dot0EncryptionProfile.h
@@ -36,7 +36,9 @@ namespace lcp
     class Lcp1dot0EncryptionProfile : public IEncryptionProfile
     {
     public:
+#if ENABLE_PROFILE_NAMES
         virtual std::string Name() const;
+#endif //ENABLE_PROFILE_NAMES
         virtual std::string UserKeyAlgorithm() const;
         virtual std::string PublicationAlgorithmGCM() const;
         virtual std::string PublicationAlgorithmCBC() const;

--- a/src/lcp-client-lib/LcpService.cpp
+++ b/src/lcp-client-lib/LcpService.cpp
@@ -448,11 +448,16 @@ namespace lcp
                 return Status(StatusCode::ErrorDecryptionLicenseEncrypted, "ErrorDecryptionLicenseEncrypted");
             }
             
+#if ENABLE_PROFILE_NAMES
             IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile(license->Crypto()->EncryptionProfile());
             if (profile == nullptr)
             {
                 return Status(StatusCode::ErrorCommonEncryptionProfileNotFound, "ErrorCommonEncryptionProfileNotFound");
             }
+#else
+            IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile();
+#endif //ENABLE_PROFILE_NAMES
+
             if (algorithm != profile->PublicationAlgorithmGCM() && algorithm != profile->PublicationAlgorithmCBC())
             {
                 return Status(StatusCode::ErrorCommonAlgorithmMismatch, "ErrorCommonAlgorithmMismatch");
@@ -499,11 +504,15 @@ namespace lcp
                 return Status(StatusCode::ErrorDecryptionLicenseEncrypted, "ErrorDecryptionLicenseEncrypted");
             }
 
+#if ENABLE_PROFILE_NAMES
             IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile(license->Crypto()->EncryptionProfile());
             if (profile == nullptr)
             {
                 return Status(StatusCode::ErrorCommonEncryptionProfileNotFound, "ErrorCommonEncryptionProfileNotFound");
             }
+#else
+            IEncryptionProfile * profile = m_encryptionProfilesManager->GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
             if (algorithm != profile->PublicationAlgorithmGCM() && algorithm != profile->PublicationAlgorithmCBC())
             {

--- a/test/lcp-client-lib/tests/CertificateTest.cpp
+++ b/test/lcp-client-lib/tests/CertificateTest.cpp
@@ -40,7 +40,12 @@ namespace lcptest
     TEST(CertificateTest, CertificateDistributionPoints)
     {
         lcp::EncryptionProfilesManager profilesManager;
+
+#if ENABLE_PROFILE_NAMES
         lcp::IEncryptionProfile * profile = profilesManager.GetProfile("http://readium.org/lcp/profile-1.0");
+#else
+        lcp::IEncryptionProfile * profile = profilesManager.GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
         ASSERT_NE(profile, nullptr);
 
@@ -55,7 +60,12 @@ namespace lcptest
     TEST(CertificateTest, CertificateRevocationList_)
     {
         lcp::EncryptionProfilesManager profilesManager;
+
+#if ENABLE_PROFILE_NAMES
         lcp::IEncryptionProfile * profile = profilesManager.GetProfile("http://readium.org/lcp/profile-1.0");
+#else
+        lcp::IEncryptionProfile * profile = profilesManager.GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
         ASSERT_NE(profile, nullptr);
 
@@ -84,7 +94,12 @@ namespace lcptest
     TEST(CertificateTest, CertificateParse)
     {
         lcp::EncryptionProfilesManager profilesManager;
+
+#if ENABLE_PROFILE_NAMES
         lcp::IEncryptionProfile * profile = profilesManager.GetProfile("http://readium.org/lcp/profile-1.0");
+#else
+        lcp::IEncryptionProfile * profile = profilesManager.GetProfile();
+#endif //ENABLE_PROFILE_NAMES
         
         ASSERT_NE(profile, nullptr);
 
@@ -98,7 +113,12 @@ namespace lcptest
     TEST(CertificateTest, CertificateVerifyByRoot)
     {
         lcp::EncryptionProfilesManager profilesManager;
+
+#if ENABLE_PROFILE_NAMES
         lcp::IEncryptionProfile * profile = profilesManager.GetProfile("http://readium.org/lcp/profile-1.0");
+#else
+        lcp::IEncryptionProfile * profile = profilesManager.GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
         ASSERT_NE(profile, nullptr);
 
@@ -111,7 +131,12 @@ namespace lcptest
     TEST(CertificateTest, CertificateVerifySignature)
     {
         lcp::EncryptionProfilesManager profilesManager;
+
+#if ENABLE_PROFILE_NAMES
         lcp::IEncryptionProfile * profile = profilesManager.GetProfile("http://readium.org/lcp/profile-1.0");
+#else
+        lcp::IEncryptionProfile * profile = profilesManager.GetProfile();
+#endif //ENABLE_PROFILE_NAMES
 
         ASSERT_NE(profile, nullptr);
 

--- a/test/lcp-client-lib/tests/CryptoppCryptoProviderTest.cpp
+++ b/test/lcp-client-lib/tests/CryptoppCryptoProviderTest.cpp
@@ -60,6 +60,7 @@ namespace lcptest
         ASSERT_EQ(lcp::StatusCode::ErrorCommonSuccess, res.Code);
     }
 
+#if ENABLE_PROFILE_NAMES
     TEST_F(CryptoppCryptoProviderTest, VerifyLicense_Return_ErrorCommonEncryptionProfileNotFound)
     {
         FakeCryptoImpl crypto;
@@ -69,6 +70,7 @@ namespace lcptest
         lcp::Status res = m_cryptoProvider->VerifyLicense(TestCertificate, &license);
         ASSERT_EQ(lcp::StatusCode::ErrorCommonEncryptionProfileNotFound, res.Code);
     }
+#endif //ENABLE_PROFILE_NAMES
 
     TEST_F(CryptoppCryptoProviderTest, VerifyLicense_Return_ErrorOpeningNoRootCertificate)
     {


### PR DESCRIPTION
...as all encryption specs can be discovered via their URI (and the server can generate both basic and v1.0 profile with identical specs)

See server code change:
https://github.com/readium/readium-lcp-server/commit/d866747ac7bbaa32ecde02a87af75ca1f949e0a3