### PR TITLE
Android / Gradle updates (current working build)

### DIFF
--- a/platform/android/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/gradle/wrapper/gradle-wrapper.properties
@@ -5,5 +5,5 @@ zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 #https://services.gradle.org/distributions
 # GRADLE EXPERIMENTAL requires 3.3
-# GRADLE STABLE works with latest (4.4)
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+# GRADLE STABLE works with latest (4.10.2)
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/platform/android/lib/build.gradle
+++ b/platform/android/lib/build.gradle
@@ -56,12 +56,12 @@ println "${lcpBuildContentFilter}"
 println "${readiumSdkLibDir}"
 println "${readiumSdkIncludeDir}"
 android {
-    compileSdkVersion 26
-    buildToolsVersion "27.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -70,7 +70,8 @@ android {
                 if (lcpBuildContentFilter) {
                     targets "clientlib", "contentfilter", "lcp"
 
-                    arguments "-DFEATURES_READIUM=1",
+                    arguments "-DCMAKE_JOB_POOLS:STRING=compile=6;link=6",
+                        "-DFEATURES_READIUM=1",
                         "-DANDROID_PLATFORM=android-19",
                         "-DANDROID_TOOLCHAIN=${toolchain}",
                         "-DANDROID_STL=${stl}",
@@ -80,7 +81,8 @@ android {
                 } else {
                     targets "clientlib", "lcp-min"
 
-                    arguments "-DANDROID_PLATFORM=android-19",
+                    arguments "-DCMAKE_JOB_POOLS:STRING=compile=6;link=6",
+                        "-DANDROID_PLATFORM=android-19",
                         "-DANDROID_TOOLCHAIN=${toolchain}",
                         "-DANDROID_STL=${stl}",
                         "-DRSDK_INCLUDE_DIR=${readiumSdkIncludeDir}",


### PR DESCRIPTION
Upgraded API 26 to 28, build tools to 28.0.3, Gradle 4.10.2, max processors / thread 6 (native NDK compiler)

Pre-requisite (must read comments, notably the "Build output" section):
https://github.com/readium/readium-sdk/pull/317

## `platform/android/local.properties`
(not checked into Git, must be created by developers)
```
sdk.dir=/PATH_TO/Android/sdk
ndk.dir=/PATH_TO/Android/sdk/ndk-bundle-old
readium.ndk_clang=false
readium.ndk_skipX86=false
readium.ndk_skipARM=false
readium.ndk_experimental=false

readium.sdk_lib_dir=/PATH_TO/SDKLauncher-Android/readium-sdk/Platform/Android/epub3/libs/
readium.sdk_include_dir=/PATH_TO/SDKLauncher-Android/readium-sdk/Platform/Android/epub3/include/
```
